### PR TITLE
starting terminal with options from config

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,12 @@
           "default": "credentials.yml",
           "description": "Ansible credential file path",
           "scope": "resource"
+        },
+        "ansible.terminalInitCommand": {
+          "type": "string",
+          "default": "",
+          "description": "Command to be run in terminal after it starts",
+          "scope": "resource"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "activationEvents": [
     "onCommand:vsc-extension-ansible.ansible-playbook",
     "onCommand:vsc-extension-ansible.ansible-commands",
-    "onCommand:vsc-extension-ansible.ansible-terminal"
+    "onCommand:vsc-extension-ansible.ansible-terminal",
+    "onCommand:vsc-extension-ansible.ansible-playbook-in-terminal"
   ],
   "main": "./out/extension",
   "contributes": {
@@ -40,6 +41,12 @@
       {
         "command": "vsc-extension-ansible.ansible-terminal",
         "title": "Terminal",
+        "args": "arguments",
+        "category": "ansible"
+      },
+      {
+        "command": "vsc-extension-ansible.ansible-playbook-in-terminal",
+        "title": "Run Ansible Playbook in Terminal",
         "args": "arguments",
         "category": "ansible"
       }
@@ -77,7 +84,7 @@
         },
         "ansible.terminalInitCommand": {
           "type": "string",
-          "default": "",
+          "default": "unconfigured",
           "description": "Command to be run in terminal after it starts",
           "scope": "resource"
         }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         },
         "ansible.terminalInitCommand": {
           "type": "string",
-          "default": "unconfigured",
+          "default": "default",
           "description": "Command to be run in terminal after it starts",
           "scope": "resource"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     let runterminal = vscode.commands.registerCommand('vsc-extension-ansible.ansible-terminal', () => {
-        terminalExecutor.startTerminal('ansible');
+        terminalExecutor.startTerminal('ansible', function() {});
     })
 
     let playbookinterminal = vscode.commands.registerCommand('vsc-extension-ansible.ansible-playbook-in-terminal', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@
 import * as vscode from 'vscode';
 import * as utilities from './utilities'; 
 import * as ansibleRunner from './ansibleRunner';
+import * as terminalExecutor from './terminalExecutor';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Congratulations, your extension "vsc-extension-ansible" is now active!');    
@@ -18,7 +19,7 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     let runterminal = vscode.commands.registerCommand('vsc-extension-ansible.ansible-terminal', () => {
-        ansibleRunner.runAnsibleDockerInTerminal(outputChannel);
+        terminalExecutor.startTerminal('ansible');
     })
 
     context.subscriptions.push(runpb);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,9 +22,14 @@ export function activate(context: vscode.ExtensionContext) {
         terminalExecutor.startTerminal('ansible');
     })
 
+    let playbookinterminal = vscode.commands.registerCommand('vsc-extension-ansible.ansible-playbook-in-terminal', () => {
+        utilities.runPlaybookInTerminal();
+    })
+
     context.subscriptions.push(runpb);
     context.subscriptions.push(runcmd);
     context.subscriptions.push(runterminal);
+    context.subscriptions.push(playbookinterminal);
     
 }
 

--- a/src/terminalExecutor.ts
+++ b/src/terminalExecutor.ts
@@ -13,26 +13,35 @@ vscode.window.onDidCloseTerminal(function (terminal) {
     }
 })
 
-export function startTerminal(terminal) {
-    if (terminals === undefined || terminals[terminal] === undefined) {
-        terminals[terminal] = vscode.window.createTerminal(terminal);
-
+export function startTerminal(terminalName, cb) {
+    if (terminals === undefined || terminals[terminalName] === undefined) {
         let cmd: string = vscode.workspace.getConfiguration('ansible').get('terminalInitCommand');
         cmd = cmd.replace('$workspace', vscode.workspace.rootPath);
+
+        var terminal = vscode.window.createTerminal(terminalName);
         
-        if (cmd != ""){
-            terminals[terminal].sendText(cmd);
+        terminals[terminalName] = terminal;
+
+        if (cmd != "") {
+            terminal.show();
+            terminal.sendText(cmd);
+
+            setTimeout(function() {
+                cb();
+            }, 1000)
+
+            return;
         }
     }
-    terminals[terminal].show();
+    terminals[terminalName].show();
+    cb();
 }
 
 export function runInTerminal(commands, terminal) {
     
-    startTerminal(terminal);
-
-    commands.forEach(element => {
-        terminals[terminal].sendText(element);
+    startTerminal(terminal, function() {
+        commands.forEach(element => {
+            terminals[terminal].sendText(element);
+        });    
     });
-
 }

--- a/src/terminalExecutor.ts
+++ b/src/terminalExecutor.ts
@@ -13,11 +13,23 @@ vscode.window.onDidCloseTerminal(function (terminal) {
     }
 })
 
-export function runInTerminal(commands, terminal) {
+export function startTerminal(terminal) {
     if (terminals === undefined || terminals[terminal] === undefined) {
         terminals[terminal] = vscode.window.createTerminal(terminal);
+
+        let cmd: string = vscode.workspace.getConfiguration('ansible').get('terminalInitCommand');
+
+        if (cmd != ""){
+            terminals[terminal].sendText(cmd);
+        }
     }
     terminals[terminal].show();
+}
+
+export function runInTerminal(commands, terminal) {
+    
+    startTerminal(terminal);
+
     commands.forEach(element => {
         terminals[terminal].sendText(element);
     });

--- a/src/terminalExecutor.ts
+++ b/src/terminalExecutor.ts
@@ -18,7 +18,8 @@ export function startTerminal(terminal) {
         terminals[terminal] = vscode.window.createTerminal(terminal);
 
         let cmd: string = vscode.workspace.getConfiguration('ansible').get('terminalInitCommand');
-
+        cmd = cmd.replace('$workspace', vscode.workspace.rootPath);
+        
         if (cmd != ""){
             terminals[terminal].sendText(cmd);
         }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -133,20 +133,6 @@ export function runPlaybookInTerminal() {
                 return;
             }
 
-            // check if terminal is configured -- if not, set default configuration
-            let cmd: string = vscode.workspace.getConfiguration('ansible').get('terminalInitCommand')
-            
-            if (cmd === "unconfigured") {
-                if (process.platform === 'win32') {
-                    // for windows we will start docker with appropriate command
-                    cmd = "docker run --rm -it -v $workspace:/current --workdir /current " + dockerImageName + " bash ; exit";
-                    vscode.workspace.getConfiguration('ansible').update('terminalInitCommand', cmd);
-                } else {
-                    // for anything else than windows, just use default terminal by default
-                    vscode.workspace.getConfiguration('ansible').update('terminalInitCommand', '');
-                }
-            }
-
             // normalize path to current workspace directory
             playbook = path.normalize(path.relative(vscode.workspace.rootPath, playbook));
             

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -139,7 +139,7 @@ export function runPlaybookInTerminal() {
             if (cmd === "unconfigured") {
                 if (process.platform === 'win32') {
                     // for windows we will start docker with appropriate command
-                    cmd = "docker run --rm -it -v $workspace:/current --workdir /current " + dockerImageName + " bash";
+                    cmd = "docker run --rm -it -v $workspace:/current --workdir /current " + dockerImageName + " bash ; exit";
                     vscode.workspace.getConfiguration('ansible').update('terminalInitCommand', cmd);
                 } else {
                     // for anything else than windows, just use default terminal by default

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -162,10 +162,11 @@ export function validatePlaybook(playbook, outputChannel) {
         isValid = false;
     }
 
-    // todo: more validation
-    outputChannel.append(message);
-    outputChannel.show();
-
+    if (outputChannel) {
+        // todo: more validation
+        outputChannel.append(message);
+        outputChannel.show();
+    }
     return isValid;
 }
 


### PR DESCRIPTION
Starting terminal should be generic and should use command from configuration file, so I have added a function called "startTerminal" and now when user selects "ansible: terminal", terminal will be started and selected command will be executed.
By default no command should be executed, but on windows we should probably add "docker run ..." as default if empty.