### PR TITLE
Improve docker run

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
         },
         "ansible.terminalInitCommand": {
           "type": "string",
-          "default": "default",
+          "default": "docker run --rm -it -v \"${workspaceFolder}:/${workspaceFolderBasename}\" ${ansible.environments} --workdir \"/${workspaceFolderBasename}\" --name \"${ansible.containerId}\" \"${ansible.dockerImage}\" bash -c \"ansible-playbook ${ansible.targetPlaybook}; bash\"",
           "description": "Command to be run in terminal after it starts"
         },
         "ansible.credentialsConfigured": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,20 +1,20 @@
 export class Constants {
-    public static ExtensionId = 'vscoss.vscode-ansible';
-    public static LineSeperator = Array(50).join('=');
-    public static AzureAccountExtensionId = 'ms-vscode.azure-account';
-    public static DockerImageName = 'microsoft/ansible:latest';
     public static AnsibleTerminalName = 'Ansible';
-    public static UserAgentName = 'VSCODEEXT_USER_AGENT';
+    public static AzureAccountExtensionId = 'ms-vscode.azure-account';
+    public static AzureManagementApiHost = 'management.azure.com';
+    public static AzureQuickStartTemplates = 'Azure/azure-quickstart-templates';
     public static Config_cloudShellConfirmed = 'cloudShellConfirmed';
     public static Config_credentialConfigured = 'credentialsConfigured';
     public static Config_credentialsFile = 'credentialsFile';
     public static Config_dockerImage = 'dockerImage';
     public static Config_terminalInitCommand = 'terminalInitCommand';
+    public static DockerImageName = 'microsoft/ansible:latest';
+    public static ExtensionId = 'vscoss.vscode-ansible';
     public static GitHubApiHost = 'api.github.com';
     public static GitHubRawContentHost = 'raw.githubusercontent.com';
-    public static AzureQuickStartTemplates = 'Azure/azure-quickstart-templates';
-    public static AzureManagementApiHost = 'management.azure.com';
+    public static LineSeperator = Array(50).join('=');
     public static NotShowThisAgain = "NotShowThisAgain";
+    public static UserAgentName = 'VSCODEEXT_USER_AGENT';
 }
 
 export enum CloudShellErrors {


### PR DESCRIPTION
## Summary

I was trying to add my own custom command, but it was too limited with options. So at first I've implemented the variable substitution for expanding the docker run command, then I
added `docker run...` to the `terminalIinitCommand` as default value in order to improve the overview and to remove the hardcoded stuffs.

It looks more user friendly now how the plugin works. What do you think?

This is what I am using now in my `settings.json`:
```json
"ansible.terminalInitCommand": "sudo docker run --rm -it -v \"${workspaceFolder}:/${workspaceFolderBasename}\" ${ansible.environments} --workdir \"/${workspaceFolderBasename}\" --name \"${ansible.containerId}\" \"${ansible.dockerImage}\" ansible-playbook \"${ansible.targetPlaybook}\""
```

## TODO

I would finish following tasks in the following days, if you like the implementation.
  - remove the `ansible.customOptions` or make it available for the compatibility support
  - update readme

## Issue Type
- New Feature